### PR TITLE
version bump to angular 1.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,10 +33,10 @@
         "url": "https://github.com/guylabs/angular-spring-data-rest.git"
     },
     "dependencies": {
-      "angular": "~1.4.8",
-      "angular-resource": "~1.4.8"
+      "angular": "~1.5.0",
+      "angular-resource": "~1.5.0"
     },
     "devDependencies": {
-      "angular-mocks": "~1.4.8"
+      "angular-mocks": "~1.5.0"
     }
 }


### PR DESCRIPTION
Updated bower.json for angular 1.5 support.
I used it with early 1.5-release candidates almost 6 months without any failures or errors related to angular.

Also the existing tests run fine.